### PR TITLE
fix/df-924: Fix test

### DIFF
--- a/tests/5.ConditionalLogin/conditional-login.spec.ts
+++ b/tests/5.ConditionalLogin/conditional-login.spec.ts
@@ -20,8 +20,9 @@ test('should be logged in and on the library page', async ({ page }) => {
   await expect(
     page.getByRole('heading', { name: 'Forms library' })
   ).toBeVisible()
+  // Use explicit regex otherwise may match additional elements on the page
   await expect(
-    page.getByRole('link', { name: process.env.AUTH_DISPLAY_NAME })
+    page.getByRole('link', { name: new RegExp(String.raw`${process.env.AUTH_DISPLAY_NAME}`) })
   ).toBeVisible()
 })
 


### PR DESCRIPTION
Multiple links matching the name = 'admin' were causing the test to fail.
The solution is to use a RegExp to more-accurately define the link match criteria. 