### PR TITLE
fix/df-1254: Fix new file upload component

### DIFF
--- a/pages/UploadPage.ts
+++ b/pages/UploadPage.ts
@@ -12,7 +12,7 @@ export class UploadPage {
     this.page = page
     this.mainHeading = page.getByRole('heading', { name: /Upload a form/i })
     this.downloadCopyLink = page.getByRole('link', { name: 'download a copy' })
-    this.fileInput = page.locator('input[type="file"][id="formDefinition"]')
+    this.fileInput = page.locator('[name="file"]')
     this.uploadButton = page.getByRole('button', { name: 'Upload form' })
     this.cancelButton = page.getByRole('button', { name: 'Cancel' })
   }
@@ -22,8 +22,12 @@ export class UploadPage {
   }
 
   async uploadFormFile(filePath: string) {
+    await this.fileInput.evaluate(
+      `element => element.style.setProperty('display', 'block')`
+    )
     await this.fileInput.setInputFiles(filePath)
-    await this.uploadButton.click()
+    await this.page.getByText('1 file uploaded', { exact: true }).isVisible()
+    await this.page.waitForTimeout(1000)
   }
 
   async clickCancel() {

--- a/tests/1.BasicFormCreationTests/1.7 - file_download_test.spec.ts
+++ b/tests/1.BasicFormCreationTests/1.7 - file_download_test.spec.ts
@@ -188,9 +188,10 @@ async function startFormIfRequired(page: Page) {
 }
 
 async function setSupportingEvidenceFile(page: Page) {
-  const fileInput = page.locator('form input[type="file"]').first()
-
-  await expect(fileInput).toBeAttached()
+  const fileInput = page.locator('form [name="file"]').first()
+  await fileInput.evaluate(
+    `element => element.style.setProperty('display', 'block')`
+  )
   await fileInput.setInputFiles(uploadFixturePath)
   await expect
     .poll(
@@ -246,19 +247,17 @@ async function waitForSupportingEvidenceUpload(
       }
     )
     .toBe(true)
-
+  await page.waitForTimeout(1000)
   return uploadResult
 }
 
 async function uploadSupportingEvidence(page: Page) {
   await setSupportingEvidenceFile(page)
-  await page.getByRole('button', { name: 'Upload file' }).click()
 
   let uploadResult = await waitForSupportingEvidenceUpload(page)
 
   if (uploadResult === 'missing-file') {
     await setSupportingEvidenceFile(page)
-    await page.getByRole('button', { name: 'Upload file' }).click()
     uploadResult = await waitForSupportingEvidenceUpload(page)
   }
 


### PR DESCRIPTION
Due to the new GDS file upload component hiding the `<input type="file">` element (so it can style over the top of it), the acceptance tests have to implement a workaround that 'unhides' the element so it can be interacted with.